### PR TITLE
fix(a11y): replace offcavas title with aria-label when not displayed

### DIFF
--- a/src/features/core/components/offcanvas/offcanvas.component.html
+++ b/src/features/core/components/offcanvas/offcanvas.component.html
@@ -8,12 +8,13 @@
   [class.hiding]="hiding$ | async"
   tabindex="-1"
   [id]="id"
-  [attr.aria-labelledby]="id + '-label'"
+  [attr.aria-labelledby]="useHeader ? id + '-label' : null"
+  [attr.aria-label]="useHeader ? null : heading"
   [attr.aria-modal]="(expanded$ | async) ? 'true' : null"
   [attr.role]="(expanded$ | async) ? 'dialog' : null"
   style="max-width: 500px">
   <div [class.offcanvas-header]="useHeader">
-    <h2 class="h5" [class.visually-hidden]="!useHeader" [id]="id + '-label'">{{ heading }}</h2>
+    <h2 *ngIf="useHeader" class="h5" [id]="id + '-label'">{{ heading }}</h2>
     <button
       *ngIf="useHeader && useCloseButton"
       type="button"


### PR DESCRIPTION
Résout les problèmes d'accessibilité suivants :
- [La hiérarchie des titres est cohérente](https://www.notion.so/Cartographie-Nationale-05422af9bf4a405d8e7b9f53373bb102?p=34d595f62fed4f489087160362e2fa53&pm=s)

Démo :
- [Cartographie](http://anct-carto-client-feature-a11y-title-hierarchy.s3-website.eu-west-3.amazonaws.com/cartographie)